### PR TITLE
proposed fix to enable the "Create Document" command

### DIFF
--- a/commands/create_document.py
+++ b/commands/create_document.py
@@ -2,7 +2,10 @@ from .base import CreateBaseCommand
 
 
 class CreateDocumentCommand(CreateBaseCommand):
-    command_name = "elasticsearch:index-document"
+    command_name = "elasticsearch:create-document"
+
+    def is_enabled(self):
+        return True
 
     def run_request(self, id=None):
         if not id:


### PR DESCRIPTION
fixed create_document.py file so that it loads correctly and shows up in the command pallet 
tested locally to make sure it works.

my environment
arch linux - 4.5.4-1-ARCH
sublime 3 - build 3114
elasticsearch - 2.3.2
